### PR TITLE
refactor: simplify concrete syntax for `App`

### DIFF
--- a/src/AlgEffectus/Core/Delab.lean
+++ b/src/AlgEffectus/Core/Delab.lean
@@ -160,11 +160,9 @@ private partial def collectList (e : Expr) : Array Expr :=
   let aTerm ← PrettyPrinter.delab a
   let fStx : TSyntax `effVal := ⟨fTerm.raw⟩
   let aStx : TSyntax `effVal := ⟨aTerm.raw⟩
-  -- Build raw syntax node  (effApp)  and coerce to `effComp`
-  let atTok : Syntax := mkAtom "@"
-  let raw   : Syntax := mkNode ``effApp #[fStx, atTok, aStx]
+  let raw   : Syntax := mkNode ``effApp #[fStx, aStx]
   let comp : TSyntax `effComp := ⟨raw⟩
-  pure comp            -- implicit coercion to `TSyntax term`
+  pure comp
 
 @[delab Computation.withC] def delabCompWith : Delab := do
   let e ← getExpr

--- a/src/AlgEffectus/Core/Elab.lean
+++ b/src/AlgEffectus/Core/Elab.lean
@@ -114,8 +114,7 @@ partial def elabCompInternal : TSyntax `effComp → TermElabM Expr
   let h' ← elabValInternal h
   let c' ← elabCompInternal c
   pure (mkApp2 (mkConst ``Computation.withC) h' c')
-| `(effComp| $f:effVal @ $arg:effVal) => do
-  -- throwIllFormedSyntax
+| `(effComp| $f:effVal $arg:effVal) => do
   let f' ← elabValInternal f
   let arg' ← elabValInternal arg
   pure (mkApp2 (mkConst ``Computation.appC) f' arg')
@@ -146,7 +145,7 @@ macro_rules
 -- test
 example := eff return true
 example := eff x
-example := eff true @ x
+example := eff true x
 example := eff (x)
 example := eff fun x ↦ return x
 example := eff handler { return x ↦ false }
@@ -168,7 +167,7 @@ eff_program demo :=
 eff_program demo2 :=
   with handler { return x ↦ return x,
                  op1(x; k) ↦ return x,
-                 op2(x; k) ↦ k @ x } handle
+                 op2(x; k) ↦ k x } handle
     do x ← return true in
     do y ← call op2(a; v. return v) in
     return x

--- a/src/AlgEffectus/Core/Parser.lean
+++ b/src/AlgEffectus/Core/Parser.lean
@@ -30,7 +30,7 @@ syntax:max "return " effVal : effComp -- `return` keyword with trailing space
 syntax:65 "call " ident "(" effVal "; " ident ". " effComp ")" : effComp
 syntax:40   "do " ident " ← " effComp " in " effComp : effComp
 syntax:45   "if " effVal " then " effComp " else " effComp : effComp
-syntax:1024 (name := effApp) effVal "@" effVal : effComp -- Application:  v @ w
+syntax:1024 (name := effApp) effVal effVal : effComp
 syntax:35 "with " effVal " handle " effComp : effComp
 syntax:1025 "(" effComp ")" : effComp
 

--- a/src/AlgEffectus/Core/PrettyPrint.lean
+++ b/src/AlgEffectus/Core/PrettyPrint.lean
@@ -16,7 +16,7 @@ mutual
     | .varV n       => n
     | .ttV          => "true"
     | .ffV          => "false"
-    | .funV x c     => s!"fun {x} ⇒ {ppComp c}"
+    | .funV x c     => s!"fun {x} ↦ {ppComp c}"
     | .handV h      => ppHandler h
 
   /-- Pretty-print a `Handler`. -/
@@ -34,7 +34,7 @@ mutual
     | .callC op arg k c     => s!"call {op} ({ppVal arg}; {k}. {ppComp c})"
     | .seqC x c₁ c₂         => s!"do {x} ← {ppComp c₁} in {ppComp c₂}"
     | .ifC b t e            => s!"if {ppVal b} then {ppComp t} else {ppComp e}"
-    | .appC f a             => s!"{ppVal f} @ {ppVal a}"
+    | .appC f a             => s!"{ppVal f} {ppVal a}"
     | .withC h c            => s!"with {ppVal h} handle {ppComp c}"
 end
 
@@ -72,7 +72,7 @@ instance : Repr Handler where
 eff_program demo2 :=
   with handler { return x ↦ return x,
                  op1(x; k) ↦ return x,
-                 op2(x; k) ↦ k @ x } handle
+                 op2(x; k) ↦ k x } handle
     do x ← return true in
     do y ← call op2(a; v. return v) in
     return x

--- a/src/AlgEffectus/Core/Semantics.lean
+++ b/src/AlgEffectus/Core/Semantics.lean
@@ -252,7 +252,7 @@ eff_program demo := if true then return x else return y
 eff_program demo2 :=
   with handler { return x ↦ return true,
                  op1(x; k) ↦ return false,
-                 read(x; k) ↦ k @ Bob } handle
+                 read(x; k) ↦ k Bob } handle
     do x ← call read(a; v. fun v ↦ return v) in
     return x
 


### PR DESCRIPTION
Remove unnecessary coercions and improve syntax definitions for `effComp` and `effVal`.